### PR TITLE
Add GA Events

### DIFF
--- a/src/components/CopyText.tsx
+++ b/src/components/CopyText.tsx
@@ -8,6 +8,7 @@ export type CopyTextProps = HTMLProps<HTMLDivElement> & {
   textToCopy?: string;
   textClassName?: string;
   copyButtonClassName?: string;
+  onCopyButtonClick?: () => void;
 };
 
 export default function CopyText({
@@ -15,9 +16,11 @@ export default function CopyText({
   textToCopy,
   textClassName,
   copyButtonClassName,
+  onCopyButtonClick,
   ...props
 }: CopyTextProps) {
   const onClickCopyToClipboard = () => {
+    onCopyButtonClick?.();
     navigator.clipboard.writeText(textToCopy || text);
     toast.success("Copied to clipboard!");
   };

--- a/src/components/EnergyAlert.tsx
+++ b/src/components/EnergyAlert.tsx
@@ -1,11 +1,21 @@
-import { Alert } from "react-daisyui";
+import { Alert, AlertProps } from "react-daisyui";
 import { HiOutlineExclamationTriangle } from "react-icons/hi2";
 import CopyText from "./CopyText";
 import Link from "./Link";
+import clsx from "clsx";
+import { toSubsocialAddress } from "@subsocial/utils";
 
-export default function EnergyAlert() {
+export type EnergyAlertProps = AlertProps & {
+  address: string;
+};
+
+export default function EnergyAlert({ address, ...props }: EnergyAlertProps) {
+  if (!address) return null;
+
   return (
-    <Alert className="rounded-lg border border-base-yellow bg-light-yellow" dataTheme="warning">
+    <Alert
+      className={clsx("rounded-lg border border-base-yellow bg-light-yellow", props.className)}
+      dataTheme="warning">
       <div className="flex flex-col">
         <div className="flex gap-1">
           <HiOutlineExclamationTriangle className="text-2xl text-base-yellow" />
@@ -15,7 +25,7 @@ export default function EnergyAlert() {
           <div className="flex flex-col gap-4">
             <div className="flex flex-col gap-2">
               <span>1. Copy the text below.</span>
-              <CopyText text="!energy 3tcZkDwdQ3dR3PMgrn8rSXBfUcZJkwmtDPvzoV3sqApSHqBw" />
+              <CopyText text={`!energy ${toSubsocialAddress(address)}`} />
             </div>
             <div>
               2. Paste the text into the energy-bot channel in our{" "}

--- a/src/components/EnergyAlert.tsx
+++ b/src/components/EnergyAlert.tsx
@@ -4,13 +4,25 @@ import CopyText from "./CopyText";
 import Link from "./Link";
 import clsx from "clsx";
 import { toSubsocialAddress } from "@subsocial/utils";
+import { useSendGaUserEvent } from "src/utils/ga/events";
 
 export type EnergyAlertProps = AlertProps & {
   address: string;
 };
 
 export default function EnergyAlert({ address, ...props }: EnergyAlertProps) {
+  const sendGaEvent = useSendGaUserEvent();
   if (!address) return null;
+
+  const onClickDiscordLink = () => {
+    sendGaEvent("Click on discord link in energy alert");
+  };
+  const onCopyButtonClick = () => {
+    sendGaEvent("Click on copy energy command button in energy alert");
+  };
+  const onCopy = () => {
+    sendGaEvent("Copy energy command in energy alert");
+  };
 
   return (
     <Alert
@@ -25,11 +37,18 @@ export default function EnergyAlert({ address, ...props }: EnergyAlertProps) {
           <div className="flex flex-col gap-4">
             <div className="flex flex-col gap-2">
               <span>1. Copy the text below.</span>
-              <CopyText text={`!energy ${toSubsocialAddress(address)}`} />
+              <CopyText
+                onCopyButtonClick={onCopyButtonClick}
+                onCopy={onCopy}
+                text={`!energy ${toSubsocialAddress(address)}`}
+              />
             </div>
             <div>
               2. Paste the text into the energy-bot channel in our{" "}
-              <Link href="https://discord.com/invite/w2Rqy2M" openInNewTab>
+              <Link
+                href="https://discord.com/invite/w2Rqy2M"
+                openInNewTab
+                onClick={onClickDiscordLink}>
                 Discord.
               </Link>
             </div>

--- a/src/components/HomeLayout.tsx
+++ b/src/components/HomeLayout.tsx
@@ -5,19 +5,25 @@ import React from "react";
 
 import Button from "./Button";
 import Container from "./Container";
+import { useSendGaUserEvent } from "src/utils/ga/events";
 
 type HomeLayoutProps = {
   children: React.ReactNode;
 };
 
 const HomeLayout = ({ children }: HomeLayoutProps) => {
+  const sendGaEvent = useSendGaUserEvent();
+  const onEnterAppClick = () => {
+    sendGaEvent("Click on Enter App button");
+  };
+
   return (
     <div className="relative flex min-h-screen flex-col">
       <header className="sticky top-0 z-20 bg-white py-4">
         <Container className="flex items-center justify-between">
           <Post4Ever className="h-3.5 md:h-4" />
           <div>
-            <Button href="/crosspost" target="_blank">
+            <Button href="/crosspost" target="_blank" onClick={onEnterAppClick}>
               Enter App
             </Button>
           </div>

--- a/src/components/SavedTweetsLinks.tsx
+++ b/src/components/SavedTweetsLinks.tsx
@@ -2,7 +2,7 @@ import React, { HTMLProps } from "react";
 import { useWalletStore } from "src/store";
 import Link from "./Link";
 import clsx from "clsx";
-import { p4eSpace } from "src/configs/spaces";
+import { getP4ESpace } from "src/configs/spaces";
 
 export type SavedTweetsLinksProps = HTMLProps<HTMLDivElement>;
 
@@ -10,7 +10,7 @@ const getLinks = (
   address: string,
 ): { text: string; href: string; openInNewTab?: boolean; authOnly?: boolean }[] => {
   const savedTweetLink = `https://polkaverse.com/accounts/${address}#tweets`;
-  const p4eSpaceLink = `https://polkaverse.com/${p4eSpace}`;
+  const p4eSpaceLink = `https://polkaverse.com/${getP4ESpace()}`;
   return [
     { text: "Twitter Backups", href: p4eSpaceLink, openInNewTab: true },
     { text: "My Saved Tweets", href: savedTweetLink, openInNewTab: true, authOnly: true },

--- a/src/components/SavedTweetsLinks.tsx
+++ b/src/components/SavedTweetsLinks.tsx
@@ -45,7 +45,8 @@ export default function SavedTweetsLinks(props: SavedTweetsLinksProps) {
 
   return (
     <div {...props} className={clsx("flex gap-6", props.className)}>
-      {linksList.map(({ href, text, openInNewTab, gaEvent }) => {
+      {linksList.map(({ href, text, openInNewTab, gaEvent, authOnly }) => {
+        if (authOnly && !address) return null;
         return (
           <Link
             href={href}

--- a/src/components/SavedTweetsLinks.tsx
+++ b/src/components/SavedTweetsLinks.tsx
@@ -3,21 +3,40 @@ import { useWalletStore } from "src/store";
 import Link from "./Link";
 import clsx from "clsx";
 import { getP4ESpace } from "src/configs/spaces";
+import { useSendGaUserEvent } from "src/utils/ga/events";
 
 export type SavedTweetsLinksProps = HTMLProps<HTMLDivElement>;
 
 const getLinks = (
   address: string,
-): { text: string; href: string; openInNewTab?: boolean; authOnly?: boolean }[] => {
+): {
+  text: string;
+  href: string;
+  openInNewTab?: boolean;
+  authOnly?: boolean;
+  gaEvent?: string;
+}[] => {
   const savedTweetLink = `https://polkaverse.com/accounts/${address}#tweets`;
   const p4eSpaceLink = `https://polkaverse.com/${getP4ESpace()}`;
   return [
-    { text: "Twitter Backups", href: p4eSpaceLink, openInNewTab: true },
-    { text: "My Saved Tweets", href: savedTweetLink, openInNewTab: true, authOnly: true },
+    {
+      text: "Twitter Backups",
+      href: p4eSpaceLink,
+      openInNewTab: true,
+      gaEvent: "Go to Twitter Backups Space",
+    },
+    {
+      text: "My Saved Tweets",
+      href: savedTweetLink,
+      openInNewTab: true,
+      authOnly: true,
+      gaEvent: "Go to My Saved Tweets",
+    },
   ];
 };
 
 export default function SavedTweetsLinks(props: SavedTweetsLinksProps) {
+  const sendGaEvent = useSendGaUserEvent();
   const { address } = useWalletStore(state => ({
     address: state.account?.address.toString(),
   }));
@@ -26,13 +45,14 @@ export default function SavedTweetsLinks(props: SavedTweetsLinksProps) {
 
   return (
     <div {...props} className={clsx("flex gap-6", props.className)}>
-      {linksList.map(({ href, text, openInNewTab }) => {
+      {linksList.map(({ href, text, openInNewTab, gaEvent }) => {
         return (
           <Link
             href={href}
             openInNewTab={openInNewTab}
             withArrowIcon={openInNewTab}
             className="!font-normal text-base-blue"
+            onClick={() => gaEvent && sendGaEvent(gaEvent)}
             key={href}>
             {text}
           </Link>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Button } from "@material-tailwind/react";
 import { useWalletStore } from "src/store";
 import type { WalletAccount } from "@talismn/connect-wallets";
+import { useSendGaUserEvent } from "src/utils/ga/events";
 
 type SidebarProps = {
   checked: boolean;
@@ -12,15 +13,18 @@ type SidebarProps = {
 };
 
 const Sidebar = ({ accounts, checked, onCheck, onChangeAccount, children }: SidebarProps) => {
+  const sendGaEvent = useSendGaUserEvent();
   const { setAccounts } = useWalletStore(state => ({
     setAccounts: state.setAccounts,
   }));
 
   const handleChangeAccount = (account: WalletAccount | null) => {
+    sendGaEvent(`Change account to ${account?.name}`);
     onChangeAccount(account);
   };
 
   const handleDisconnect = () => {
+    sendGaEvent("Disconnect wallet");
     setAccounts(undefined);
     handleChangeAccount(null);
   };

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -19,7 +19,7 @@ const Sidebar = ({ accounts, checked, onCheck, onChangeAccount, children }: Side
   }));
 
   const handleChangeAccount = (account: WalletAccount | null) => {
-    sendGaEvent(`Change account to ${account?.name}`);
+    sendGaEvent(`Change account to ${account?.address}`);
     onChangeAccount(account);
   };
 

--- a/src/components/cards/FetchTweetCard.tsx
+++ b/src/components/cards/FetchTweetCard.tsx
@@ -12,6 +12,7 @@ import TweetBody from "../render/TweetBody";
 import { rootInput } from "styles/common";
 import { BaseTweetProps } from "src/types/common";
 import { urlMatcher } from "src/utils/string";
+import { useSendGaUserEvent } from "src/utils/ga/events";
 
 type FetchTweetCardProps = {
   disabled: boolean;
@@ -22,6 +23,7 @@ const returnRemovedUrlIdx = (firstCondition: boolean, secondCondition: boolean) 
   firstCondition && secondCondition ? -2 : -1;
 
 const FetchTweetCard = ({ disabled, onFetchTweet }: FetchTweetCardProps) => {
+  const sendGaEvent = useSendGaUserEvent();
   // const { data: session, status } = useSession();
 
   const [tweetUrl, setTweetUrl] = useState("");
@@ -37,6 +39,7 @@ const FetchTweetCard = ({ disabled, onFetchTweet }: FetchTweetCardProps) => {
   }, [fetchedTweet]);
 
   const handleFetchTweet = async () => {
+    sendGaEvent("Click on find tweet button");
     setLoadingTweet(true);
     setFetchedTweet(null);
 

--- a/src/components/cards/SendTweetCard.tsx
+++ b/src/components/cards/SendTweetCard.tsx
@@ -13,6 +13,7 @@ import { SUB_IPFS_NODE_URL } from "src/configs/sdk-network-config";
 import { rootInput } from "styles/common";
 import EnergyAlert from "components/EnergyAlert";
 import { useMyBalance } from "src/hooks/use-balance";
+import { getP4ESpace } from "src/configs/spaces";
 
 type SendTweetCardProps = {
   disabled: boolean;
@@ -34,7 +35,7 @@ const SendTweetCard = ({ disabled, fetchedTweet, onSuccess }: SendTweetCardProps
     account: state.account,
   }));
 
-  const [selectedSpaceId, setSelectedSpaceId] = useState<string | null>(null);
+  const [selectedSpaceId, setSelectedSpaceId] = useState<string | null>(getP4ESpace());
 
   useEffect(() => {
     setSelectedSpaceId(null);
@@ -123,7 +124,7 @@ const SendTweetCard = ({ disabled, fetchedTweet, onSuccess }: SendTweetCardProps
           )}
         </div>
 
-        {!hasToken && !disabled && <EnergyAlert />}
+        {!hasToken && !disabled && <EnergyAlert address={account?.address ?? ''} />}
 
         {!account || !fetchedTweet || !selectedSpaceId ? (
           <Tooltip

--- a/src/components/cards/SendTweetCard.tsx
+++ b/src/components/cards/SendTweetCard.tsx
@@ -14,6 +14,7 @@ import { rootInput } from "styles/common";
 import EnergyAlert from "components/EnergyAlert";
 import { useMyBalance } from "src/hooks/use-balance";
 import { getP4ESpace } from "src/configs/spaces";
+import { useSendGaUserEvent } from "src/utils/ga/events";
 
 type SendTweetCardProps = {
   disabled: boolean;
@@ -22,6 +23,7 @@ type SendTweetCardProps = {
 };
 
 const SendTweetCard = ({ disabled, fetchedTweet, onSuccess }: SendTweetCardProps) => {
+  const sendGaEvent = useSendGaUserEvent();
   const {
     loadingSpaces,
     loadingCreatePost,
@@ -49,6 +51,7 @@ const SendTweetCard = ({ disabled, fetchedTweet, onSuccess }: SendTweetCardProps
   const handleChangeSpaceId = (value?: React.ReactNode) => {
     const spaceId = value as string;
     if (spaceId) {
+      sendGaEvent(`Change space id to ${spaceId}`);
       setSelectedSpaceId(spaceId);
     }
   };
@@ -61,6 +64,7 @@ const SendTweetCard = ({ disabled, fetchedTweet, onSuccess }: SendTweetCardProps
 
   const handleCreatePostWithSpaceId = () => {
     if (fetchedTweet && account && selectedSpaceId) {
+      sendGaEvent("Click on Publish to Subsocial button");
       createPostWithSpaceId({
         account,
         content: fetchedTweet,

--- a/src/components/cards/SendTweetCard.tsx
+++ b/src/components/cards/SendTweetCard.tsx
@@ -38,7 +38,7 @@ const SendTweetCard = ({ disabled, fetchedTweet, onSuccess }: SendTweetCardProps
   const [selectedSpaceId, setSelectedSpaceId] = useState<string | null>(getP4ESpace());
 
   useEffect(() => {
-    setSelectedSpaceId(null);
+    setSelectedSpaceId(getP4ESpace());
     if (account) {
       checkSpaceOwnedBy(account);
     }
@@ -70,6 +70,12 @@ const SendTweetCard = ({ disabled, fetchedTweet, onSuccess }: SendTweetCardProps
     }
   };
 
+  let disabledButtonTooltip = "";
+  if (!account) disabledButtonTooltip = "Please connect wallet first";
+  else if (!fetchedTweet) disabledButtonTooltip = "Please find a tweet first";
+  else if (!hasToken) disabledButtonTooltip = "Please follow the command above to get some energy";
+  else if (!selectedSpaceId) disabledButtonTooltip = "Please select a space first";
+
   return (
     <WrapperCard id={"send-tweet-card"}>
       <h2
@@ -83,14 +89,13 @@ const SendTweetCard = ({ disabled, fetchedTweet, onSuccess }: SendTweetCardProps
         <div>
           {loadingSpaces ? (
             <Skeleton className="h-[35px]" />
-          ) : spaces ? (
+          ) : spaces && !disabled ? (
             <Select
+              key="select-space"
+              value={selectedSpaceId ?? undefined}
               label="Space"
-              disabled={disabled}
               onChange={value => handleChangeSpaceId(value)}
-              className={clsx("!rounded-lg bg-[#FAFBFB]", {
-                "cursor-not-allowed": disabled,
-              })}>
+              className={clsx("!rounded-lg bg-[#FAFBFB]")}>
               {spaces.map(space => (
                 <Option key={space.id} value={`${space.id}`} className="flex items-center gap-2">
                   <div className="flex items-center gap-2">
@@ -124,18 +129,10 @@ const SendTweetCard = ({ disabled, fetchedTweet, onSuccess }: SendTweetCardProps
           )}
         </div>
 
-        {!hasToken && !disabled && <EnergyAlert address={account?.address ?? ''} />}
+        {!hasToken && !disabled && <EnergyAlert address={account?.address ?? ""} />}
 
-        {!account || !fetchedTweet || !selectedSpaceId ? (
-          <Tooltip
-            className="cursor-not-allowed"
-            message={
-              !account
-                ? "Please connect wallet first"
-                : !fetchedTweet
-                ? "Please find a tweet first"
-                : "Please connect wallet with space first"
-            }>
+        {disabledButtonTooltip ? (
+          <Tooltip className="cursor-not-allowed" message={disabledButtonTooltip}>
             <Button fullWidth className="normal-case" disabled>
               {BUTTON_TEXT}
             </Button>

--- a/src/components/wallet-connect/ConnectButton.tsx
+++ b/src/components/wallet-connect/ConnectButton.tsx
@@ -1,11 +1,14 @@
 import NewLogoPolkadot from "public/images/NewLogoPolkadot.svg";
+import { useSendGaUserEvent } from "src/utils/ga/events";
 
 type ConnectButtonProps = {
   onConnect: () => void;
 };
 
 const ConnectButton = ({ onConnect }: ConnectButtonProps) => {
+  const sendGaEvent = useSendGaUserEvent();
   const handleConnect = () => {
+    sendGaEvent("Click on connect wallet button");
     onConnect();
   };
 

--- a/src/configs/spaces.ts
+++ b/src/configs/spaces.ts
@@ -1,2 +1,5 @@
 const defaultP4eSpace = "10102";
-export const p4eSpace = process.env["NEXT_PUBLIC_P4E_SPACE"] ?? defaultP4eSpace;
+const p4eSpace = process.env["NEXT_PUBLIC_P4E_SPACE"] ?? defaultP4eSpace;
+export function getP4ESpace() {
+  return p4eSpace;
+}

--- a/src/configs/spaces.ts
+++ b/src/configs/spaces.ts
@@ -1,5 +1,5 @@
 const defaultP4eSpace = "10102";
-const p4eSpace = process.env["NEXT_PUBLIC_P4E_SPACE"] ?? defaultP4eSpace;
+const p4eSpace = process.env["NEXT_PUBLIC_P4E_SPACE"] || defaultP4eSpace;
 export function getP4ESpace() {
   return p4eSpace;
 }

--- a/src/hooks/use-subsocial-api.ts
+++ b/src/hooks/use-subsocial-api.ts
@@ -21,7 +21,7 @@ import {
 import { TweetUserProps, TweetContentProps, TweetWithIncludesProps } from "src/types/common";
 import { SubmittableResult } from "@polkadot/api";
 import { WalletAccount } from "@talismn/connect-wallets";
-import { p4eSpace } from "src/configs/spaces";
+import { getP4ESpace } from "src/configs/spaces";
 
 type SavePostContentProps = {
   author: TweetUserProps;
@@ -244,7 +244,7 @@ export const useSubSocialApiHook = () => {
       if (!myOwnSpaceIds && !editableSpaceIds) return null;
 
       const convertedAllSpaceIds = [
-        p4eSpace,
+        getP4ESpace(),
         ...bnsToIds(myOwnSpaceIds),
         ...(editableSpaceIds || []),
       ];

--- a/src/utils/ga/categories.ts
+++ b/src/utils/ga/categories.ts
@@ -1,0 +1,8 @@
+const categories = {
+  user: {
+    guest: "Guest",
+    signin: "Signed In User",
+  },
+};
+
+export default categories;

--- a/src/utils/ga/events.ts
+++ b/src/utils/ga/events.ts
@@ -1,0 +1,40 @@
+import { event } from "nextjs-google-analytics";
+import categories from "./categories";
+import { useWalletStore } from "src/store";
+import { useCallback } from "react";
+
+type CreateEventProps = {
+  category: string;
+  action: string;
+  userId?: string;
+};
+
+const sendGaEvent = ({ action, category, userId }: CreateEventProps) => {
+  event(action, { category, userId });
+};
+
+export const sendGuestGaEvent = (action: string) =>
+  sendGaEvent({
+    category: categories.user.guest,
+    action,
+  });
+
+export const sendSignedInGaEvent = (action: string, address?: string) =>
+  sendGaEvent({
+    category: categories.user.signin,
+    action,
+    userId: address,
+  });
+
+export const useSendGaUserEvent = () => {
+  const { address } = useWalletStore(state => ({
+    address: state.account?.address,
+  }));
+  const memoizedSignInGaEvent = useCallback(
+    (action: string) => sendSignedInGaEvent(action, address),
+    [address],
+  );
+  const sendGAEvent = address ? memoizedSignInGaEvent : sendGuestGaEvent;
+
+  return sendGAEvent;
+};


### PR DESCRIPTION
This GA Event also include `userId` using the address of connected account.

# List of Events
- Connect wallet => Click on connect wallet button
- Change account => Change account to {address}
- Disconnect => Disconnect wallet
- Find Tweet => Click on find tweet button
- Change space id => Change space id to {spaceId}
- Publish => Click on Publish to Subsocial button
- Discord link in energy alert => Click on discord link in energy alert
- Click copy button in energy alert => Click on copy energy command button in energy alert
- Copy energy command => Click on copy energy command button in energy alert
- Click on `Twitter Backups` link => Go to Twitter Backups Space
- Click on `My Saved Tweets` => Go to My Saved Tweets

# Other Changes
- Remove `My Saved Tweet` link if not login.

# To be confirmed
- Do you want to add address as userId for every ga event?
- Do you want to save user `address` in change account event?
- Do you want to save `spaceId` in change space event?