### PR TITLE
Fix success modal not showing after tx succeed

### DIFF
--- a/src/hooks/use-subsocial-api.ts
+++ b/src/hooks/use-subsocial-api.ts
@@ -132,10 +132,9 @@ export const useSubSocialApiHook = () => {
   }: SendSignedTxProps) => {
     if (!signer) throw new Error("No signer provided");
 
-    let unsub: (() => void) | undefined = undefined;
     try {
       const tx = await extrinsic.signAsync(address, { signer });
-      unsub = await tx.send(result => onSuccessCallback(result, toastId, successCallback, spaceId));
+      tx.send(result => onSuccessCallback(result, toastId, successCallback, spaceId));
     } catch (error) {
       if (error instanceof Error && error.message === "Cancelled") {
         toast("Cancelled!", {
@@ -144,8 +143,6 @@ export const useSubSocialApiHook = () => {
         setLoadingCreatePost(false);
       }
       console.warn({ error });
-    } finally {
-      unsub?.();
     }
   };
 


### PR DESCRIPTION
# Problem
It unsub the transaction before it even finishes

Its from this PR #24
![image](https://user-images.githubusercontent.com/53143942/219705219-9d1411ca-a839-4ec9-9e51-951ed57bcb45.png)

So I revert this change and remove unused var 

# Related task
https://app.clickup.com/t/860pz3y6u