### PR TITLE
UI Improvements

### DIFF
--- a/src/components/EnergyAlert.tsx
+++ b/src/components/EnergyAlert.tsx
@@ -29,7 +29,7 @@ export default function EnergyAlert({ address, ...props }: EnergyAlertProps) {
       className={clsx("rounded-lg border border-base-yellow bg-light-yellow", props.className)}
       dataTheme="warning">
       <div className="flex flex-col">
-        <div className="flex gap-1">
+        <div className="flex items-center gap-1">
           <HiOutlineExclamationTriangle className="text-2xl text-base-yellow" />
           <span className="font-semibold text-base-yellow">You need energy to save a tweet</span>
         </div>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -75,7 +75,7 @@ const Layout = ({ onConnect, account, accounts, children }: LayoutProps) => {
               )}
             </div>
           </div>
-          <main className="relative">{children}</main>
+          <main className="relative text-base">{children}</main>
         </div>
       </Sidebar>
     </>

--- a/src/components/SavedTweetsLinks.tsx
+++ b/src/components/SavedTweetsLinks.tsx
@@ -4,6 +4,7 @@ import Link from "./Link";
 import clsx from "clsx";
 import { getP4ESpace } from "src/configs/spaces";
 import { useSendGaUserEvent } from "src/utils/ga/events";
+import { toSubsocialAddress } from "@subsocial/utils";
 
 export type SavedTweetsLinksProps = HTMLProps<HTMLDivElement>;
 
@@ -16,7 +17,7 @@ const getLinks = (
   authOnly?: boolean;
   gaEvent?: string;
 }[] => {
-  const savedTweetLink = `https://polkaverse.com/accounts/${address}#tweets`;
+  const savedTweetLink = `https://polkaverse.com/accounts/${toSubsocialAddress(address)}#tweets`;
   const p4eSpaceLink = `https://polkaverse.com/${getP4ESpace()}`;
   return [
     {

--- a/src/components/SavedTweetsLinks.tsx
+++ b/src/components/SavedTweetsLinks.tsx
@@ -52,7 +52,7 @@ export default function SavedTweetsLinks(props: SavedTweetsLinksProps) {
             href={href}
             openInNewTab={openInNewTab}
             withArrowIcon={openInNewTab}
-            className="text-base !font-normal text-base-blue"
+            className="!font-normal text-base-blue"
             onClick={() => gaEvent && sendGaEvent(gaEvent)}
             key={href}>
             {text}

--- a/src/components/SavedTweetsLinks.tsx
+++ b/src/components/SavedTweetsLinks.tsx
@@ -52,7 +52,7 @@ export default function SavedTweetsLinks(props: SavedTweetsLinksProps) {
             href={href}
             openInNewTab={openInNewTab}
             withArrowIcon={openInNewTab}
-            className="!font-normal text-base-blue"
+            className="text-base !font-normal text-base-blue"
             onClick={() => gaEvent && sendGaEvent(gaEvent)}
             key={href}>
             {text}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -93,14 +93,6 @@ select:-webkit-autofill:focus {
 .btn-outline.btn-accent {
   background: linear-gradient(white, white) padding-box,
     linear-gradient(to right, hsla(327, 83%, 56%, 1), hsla(213, 75%, 61%, 1)) border-box;
-  border-radius: 10px;
-  border: 1px solid transparent;
-}
-
-.btn-outline.btn-accent {
-  background: linear-gradient(white, white) padding-box,
-    linear-gradient(to right, hsla(327, 83%, 56%, 1), hsla(213, 75%, 61%, 1)) border-box;
-  border-radius: 10px;
   border: 1px solid transparent;
 }
 


### PR DESCRIPTION
# Changes
- On Mac browsers, the usual text font sizes are 14px, not 16px. To fix this, I add text-base class in `main` tag to make all texts defaults to 16px explicitly.
- Adjust border radius of outline button
- Fix alignment of warning icon in no energy alert

# Bug Fix
- Link to my saved tweets are using raw address from wallet, so it's using substrate address format, while in polkaverse, we need it to be subsocial address format.