### PR TITLE
Remove query param from tweet

### DIFF
--- a/src/components/cards/FetchTweetCard.tsx
+++ b/src/components/cards/FetchTweetCard.tsx
@@ -46,7 +46,8 @@ const FetchTweetCard = ({ disabled, onFetchTweet }: FetchTweetCardProps) => {
     setFetchedTweet(null);
 
     try {
-      const tweetId = tweetUrl.split("/")[5];
+      const [tweetWithoutUrl] = tweetUrl.split("?");
+      const tweetId = tweetWithoutUrl.split("/")[5];
 
       const response = await fetch(`/api/crosspost?tweetId=${tweetId}`, {
         method: "GET",


### PR DESCRIPTION
# Problem
If you use the link from twitter app, it has query parameters in the url
this makes the backend returns empty object for that tweet.

# Solution
Remove query params